### PR TITLE
Strong mode mirror support for rpc package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1
+
+- Support strong-mode mirrors (https://github.com/dart-lang/sdk/issues/35611).
+
 ## 0.6.0
 
 - Support latest `package:gcloud`.

--- a/lib/src/config/property.dart
+++ b/lib/src/config/property.dart
@@ -5,7 +5,7 @@
 part of rpc.config;
 
 /// [D] is the type used in Dart code.  [J] is the type used in JSON.
-class ApiConfigSchemaProperty<D, J> {
+abstract class ApiConfigSchemaProperty<D, J> {
   final String name;
   final String description;
   final bool required;
@@ -359,9 +359,8 @@ class ListProperty<D> extends ApiConfigSchemaProperty<List<D>, List> {
   }
 }
 
-class MapProperty extends ApiConfigSchemaProperty<Map<String, dynamic>,
-    Map<String, dynamic>> {
-  final dynamic _additionalProperty;
+class MapProperty<D> extends ApiConfigSchemaProperty<Map<String, D>, Map> {
+  final ApiConfigSchemaProperty _additionalProperty;
 
   MapProperty(
       String name, String description, bool required, this._additionalProperty)
@@ -373,18 +372,18 @@ class MapProperty extends ApiConfigSchemaProperty<Map<String, dynamic>,
   discovery.JsonSchema get asDiscovery =>
       super.asDiscovery..additionalProperties = _additionalProperty.asDiscovery;
 
-  Map<String, dynamic> _toResponse(Map<String, dynamic> mapObject) {
-    var result = <String, dynamic>{};
-    mapObject.forEach((String key, object) {
+  Map _toResponse(Map<String, D> mapObject) {
+    var result = {};
+    mapObject.forEach((String key, D object) {
       result[key] = _additionalProperty._toResponse(object);
     });
     return result;
   }
 
-  Map<String, dynamic> _fromRequest(Map<String, dynamic> encodedMap) {
+  Map<String, D> _fromRequest(Map encodedMap) {
     // Map from String to the type of the additional property.
-    var result = <String, dynamic>{};
-    encodedMap.forEach((String key, encodedObject) {
+    var result = <String, D>{};
+    encodedMap.forEach((key, encodedObject) {
       result[key] = _additionalProperty._fromRequest(encodedObject);
     });
     return result;

--- a/lib/src/config/property.dart
+++ b/lib/src/config/property.dart
@@ -312,18 +312,18 @@ class DateTimeProperty extends ApiConfigSchemaProperty<DateTime, String> {
   }
 }
 
-class SchemaProperty<D, J extends Map> extends ApiConfigSchemaProperty<dynamic, dynamic> {
+class SchemaProperty<D> extends ApiConfigSchemaProperty<D, dynamic> {
   final ApiConfigSchema _ref;
 
   SchemaProperty(String name, String description, bool required, this._ref)
       : super(name, description, required, null, null, null);
 
-  dynamic _toResponse(value) {
+  dynamic _toResponse(D value) {
     assert(value != null);
     return _ref.toResponse(value);
   }
 
-  dynamic _fromRequest(value) {
+  D _fromRequest(dynamic value) {
     assert(value != null);
     if (value is! Map && value is! MediaMessage) {
       throw new BadRequestError('Invalid request message');

--- a/lib/src/config/property.dart
+++ b/lib/src/config/property.dart
@@ -312,18 +312,18 @@ class DateTimeProperty extends ApiConfigSchemaProperty<DateTime, String> {
   }
 }
 
-class SchemaProperty extends ApiConfigSchemaProperty<dynamic, dynamic> {
+class SchemaProperty<D, J extends Map> extends ApiConfigSchemaProperty<dynamic, dynamic> {
   final ApiConfigSchema _ref;
 
   SchemaProperty(String name, String description, bool required, this._ref)
       : super(name, description, required, null, null, null);
 
-  dynamic _toResponse(dynamic value) {
+  dynamic _toResponse(value) {
     assert(value != null);
     return _ref.toResponse(value);
   }
 
-  dynamic _fromRequest(dynamic value) {
+  dynamic _fromRequest(value) {
     assert(value != null);
     if (value is! Map && value is! MediaMessage) {
       throw new BadRequestError('Invalid request message');
@@ -337,7 +337,7 @@ class SchemaProperty extends ApiConfigSchemaProperty<dynamic, dynamic> {
   bool get isSimple => false;
 }
 
-class ListProperty extends ApiConfigSchemaProperty<List, List> {
+class ListProperty<D> extends ApiConfigSchemaProperty<List<D>, List> {
   final ApiConfigSchemaProperty _itemsProperty;
 
   ListProperty(
@@ -350,12 +350,12 @@ class ListProperty extends ApiConfigSchemaProperty<List, List> {
   discovery.JsonSchema get asDiscovery =>
       super.asDiscovery..items = _itemsProperty.asDiscovery;
 
-  List _toResponse(List listObject) {
+  List _toResponse(List<D> listObject) {
     return listObject.map(_itemsProperty._toResponse).toList();
   }
 
-  List _fromRequest(List encodedList) {
-    return encodedList.map(_itemsProperty._fromRequest).toList();
+  List<D> _fromRequest(List encodedList) {
+    return encodedList.map<D>(_itemsProperty._fromRequest as D Function(Object)).toList();
   }
 }
 

--- a/lib/src/config/schema.dart
+++ b/lib/src/config/schema.dart
@@ -48,7 +48,7 @@ class ApiConfigSchema {
     InstanceMirror schema = schemaClass.newInstance(new Symbol(''), []);
     for (Symbol sym in _properties.keys) {
       final ApiConfigSchemaProperty prop = _properties[sym];
-      try {
+      //try {
         if (request.containsKey(prop.name)) {
           // MediaMessage special case
           if (request[prop.name] is MediaMessage ||
@@ -74,9 +74,9 @@ class ApiConfigSchema {
         } else if (prop.required) {
           throw new BadRequestError('Required field ${prop.name} is missing');
         }
-      } on TypeError catch (e) {
+      /*} on TypeError catch (e) {
         throw BadRequestError('Field ${prop.name} has wrong type:  ${e}');
-      }
+      }*/
     }
     return schema.reflectee;
   }

--- a/lib/src/config/schema.dart
+++ b/lib/src/config/schema.dart
@@ -44,7 +44,7 @@ abstract class ApiConfigSchema<D, J> {
   J toResponse(D result);
 }
 
-// TODO(jcollins-j): consider `J extends Map`
+// TODO(jcollins-g): consider `J extends Map`
 class ConfigSchema<D, J> extends ApiConfigSchema<D, J> {
   ConfigSchema(String schemaName, ClassMirror schemaClass, bool isRequest)
       : super(schemaName, schemaClass, isRequest);

--- a/lib/src/config/schema.dart
+++ b/lib/src/config/schema.dart
@@ -4,7 +4,8 @@
 
 part of rpc.config;
 
-class ApiConfigSchema {
+/// [D] is the type used in Dart code.  [J] is the type used in JSON.
+abstract class ApiConfigSchema<D, J> {
   final String schemaName;
   final ClassMirror schemaClass;
   final Map<Symbol, ApiConfigSchemaProperty> _properties = {};
@@ -39,49 +40,58 @@ class ApiConfigSchema {
     return schema;
   }
 
-  fromRequest(request) {
-    if (request is! Map) {
+  D fromRequest(J request);
+  J toResponse(D result);
+}
+
+class ConfigSchema<D, J> extends ApiConfigSchema<D, J> {
+  ConfigSchema(String schemaName, ClassMirror schemaClass, bool isRequest)
+      : super(schemaName, schemaClass, isRequest);
+
+  D fromRequest(J request) {
+    if (request is Map) {
+      InstanceMirror schema = schemaClass.newInstance(new Symbol(''), []);
+      for (Symbol sym in _properties.keys) {
+        final ApiConfigSchemaProperty prop = _properties[sym];
+        try {
+          if (request.containsKey(prop.name)) {
+            // MediaMessage special case
+            if (request[prop.name] is MediaMessage ||
+                request[prop.name] is List<MediaMessage>) {
+              // If in form, there is an (input[type="file"] multiple) and the user
+              // put only one file. It's not an error and it should be accept.
+              // Maybe it cans be optimized.
+              if (schema.type.instanceMembers[sym].returnType.reflectedType
+                  .toString() ==
+                  'List<MediaMessage>' &&
+                  request[prop.name] is MediaMessage) {
+                schema.setField(sym, [request[prop.name]]);
+              } else if (request[prop.name] is List) {
+                schema.setField(sym, prop.fromRequest(request[prop.name]));
+              } else {
+                schema.setField(sym, request[prop.name]);
+              }
+            } else {
+              schema.setField(sym, prop.fromRequest(request[prop.name]));
+            }
+          } else if (prop.hasDefault) {
+            schema.setField(sym, prop.fromRequest(prop.defaultValue));
+          } else if (prop.required) {
+            throw new BadRequestError('Required field ${prop.name} is missing');
+          }
+        } on TypeError catch (e) {
+          throw BadRequestError('Field ${prop.name} has wrong type:  ${e}');
+        }
+      }
+      return schema.reflectee;
+    } else {
       throw new BadRequestError(
           'Invalid parameter: \'$request\', should be an instance of type '
-          '\'$schemaName\'.');
+              '\'$schemaName\'.');
     }
-    InstanceMirror schema = schemaClass.newInstance(new Symbol(''), []);
-    for (Symbol sym in _properties.keys) {
-      final ApiConfigSchemaProperty prop = _properties[sym];
-      //try {
-        if (request.containsKey(prop.name)) {
-          // MediaMessage special case
-          if (request[prop.name] is MediaMessage ||
-              request[prop.name] is List<MediaMessage>) {
-            // If in form, there is an (input[type="file"] multiple) and the user
-            // put only one file. It's not an error and it should be accept.
-            // Maybe it cans be optimized.
-            if (schema.type.instanceMembers[sym].returnType.reflectedType
-                        .toString() ==
-                    'List<MediaMessage>' &&
-                request[prop.name] is MediaMessage) {
-              schema.setField(sym, [request[prop.name]]);
-            } else if (request[prop.name] is List) {
-              schema.setField(sym, prop.fromRequest(request[prop.name]));
-            } else {
-              schema.setField(sym, request[prop.name]);
-            }
-          } else {
-            schema.setField(sym, prop.fromRequest(request[prop.name]));
-          }
-        } else if (prop.hasDefault) {
-          schema.setField(sym, prop.fromRequest(prop.defaultValue));
-        } else if (prop.required) {
-          throw new BadRequestError('Required field ${prop.name} is missing');
-        }
-      /*} on TypeError catch (e) {
-        throw BadRequestError('Field ${prop.name} has wrong type:  ${e}');
-      }*/
-    }
-    return schema.reflectee;
   }
 
-  toResponse(result) {
+  J toResponse(D result) {
     var response = {};
     InstanceMirror mirror = reflect(result);
     _properties.forEach((sym, prop) {
@@ -90,13 +100,13 @@ class ApiConfigSchema {
         response[prop.name] = value;
       }
     });
-    return response;
+    return response as J;
   }
 }
 
 // Schema for explicitly handling List<'some value'> as either return
 // or argument type. For the arguments it is only supported for POST requests.
-class NamedListSchema extends ApiConfigSchema {
+class NamedListSchema<D> extends ApiConfigSchema<List<D>, List> {
   ApiConfigSchemaProperty _itemsProperty;
 
   NamedListSchema(String schemaName, ClassMirror schemaClass, bool isRequest)
@@ -118,25 +128,20 @@ class NamedListSchema extends ApiConfigSchema {
     return schema;
   }
 
-  fromRequest(request) {
-    if (request is! List) {
-      throw new BadRequestError(
-          'Invalid parameter: \'$request\', should be an instance of type '
-          '\'$schemaName\'.');
-    }
+  List<D> fromRequest(List request) {
     // TODO: Performance optimization, we don't need to decode a list of
     // primitive-type since it is already the correct list.
-    return request.map(_itemsProperty.fromRequest).toList();
+    return request.map(_itemsProperty.fromRequest as D Function(Object)).toList();
   }
 
   // TODO: Performance optimization, we don't need to encode a list of
   // primitive-type since it is already the correct list.
-  toResponse(result) => result.map(_itemsProperty.toResponse).toList();
+  List toResponse(List<D> result) => result.map(_itemsProperty.toResponse).toList();
 }
 
 // Schema for explicitly handling Map<String, 'some value'> as either return
 // or argument type. For the arguments it is only supported for POST requests.
-class NamedMapSchema extends ApiConfigSchema {
+class NamedMapSchema<D> extends ApiConfigSchema<Map<String, D>, Map> {
   ApiConfigSchemaProperty _additionalProperty;
 
   NamedMapSchema(String schemaName, ClassMirror schemaClass, bool isRequest)
@@ -158,27 +163,22 @@ class NamedMapSchema extends ApiConfigSchema {
     return schema;
   }
 
-  fromRequest(request) {
-    if (request is! Map) {
-      throw new BadRequestError(
-          'Invalid parameter: \'$request\', must be an instance of type '
-          '\'$schemaName\'.');
-    }
+  Map<String, D> fromRequest(Map request) {
     // Map from String to the type of the additional property.
-    var decodedRequest = {};
+    var decodedRequest = <String, D>{};
     // TODO: Performance optimization, we don't need to decode a map from
     // <String, primitive-type> since it is already the correct map.
-    request.forEach((String key, value) {
+    request.forEach((key, value) {
       decodedRequest[key] = _additionalProperty.fromRequest(value);
     });
     return decodedRequest;
   }
 
-  toResponse(result) {
+  Map toResponse(Map<String, D> result) {
     var encodedResult = {};
     // TODO: Performance optimization, we don't need to encode a map from
     // <String, primitive-type> since it is already the correct map.
-    (result as Map<dynamic, dynamic>).forEach((key, value) {
+    result.forEach((key, value) {
       encodedResult[key] = _additionalProperty.toResponse(value);
     });
     return encodedResult;

--- a/lib/src/config/schema.dart
+++ b/lib/src/config/schema.dart
@@ -84,11 +84,10 @@ class ConfigSchema<D, J> extends ApiConfigSchema<D, J> {
         }
       }
       return schema.reflectee;
-    } else {
-      throw new BadRequestError(
-          'Invalid parameter: \'$request\', should be an instance of type '
-              '\'$schemaName\'.');
     }
+    throw new BadRequestError(
+        'Invalid parameter: \'$request\', should be an instance of type '
+            '\'$schemaName\'.');
   }
 
   J toResponse(D result) {

--- a/lib/src/config/schema.dart
+++ b/lib/src/config/schema.dart
@@ -44,6 +44,7 @@ abstract class ApiConfigSchema<D, J> {
   J toResponse(D result);
 }
 
+// TODO(jcollins-j): consider `J extends Map`
 class ConfigSchema<D, J> extends ApiConfigSchema<D, J> {
   ConfigSchema(String schemaName, ClassMirror schemaClass, bool isRequest)
       : super(schemaName, schemaClass, isRequest);

--- a/lib/src/config/schema.dart
+++ b/lib/src/config/schema.dart
@@ -44,6 +44,8 @@ abstract class ApiConfigSchema<D, J> {
   J toResponse(D result);
 }
 
+final Type _listOfMediaMessage = reflectType(List, [MediaMessage]).reflectedType;
+
 // TODO(jcollins-g): consider `J extends Map`
 class ConfigSchema<D, J> extends ApiConfigSchema<D, J> {
   ConfigSchema(String schemaName, ClassMirror schemaClass, bool isRequest)
@@ -63,7 +65,7 @@ class ConfigSchema<D, J> extends ApiConfigSchema<D, J> {
               // If in form, there is an (input[type="file"] multiple) and the user
               // put only one file. It's not an error and it should be accept.
               // Maybe it cans be optimized.
-              if (schema.type.instanceMembers[sym].returnType.reflectedType is List<MediaMessage> &&
+              if (schema.type.instanceMembers[sym].returnType.reflectedType == _listOfMediaMessage &&
                   requestForSymbol is MediaMessage) {
                 schema.setField(sym, [requestForSymbol]);
               } else if (requestForSymbol is List) {

--- a/lib/src/config/schema.dart
+++ b/lib/src/config/schema.dart
@@ -56,24 +56,23 @@ class ConfigSchema<D, J> extends ApiConfigSchema<D, J> {
         final ApiConfigSchemaProperty prop = _properties[sym];
         try {
           if (request.containsKey(prop.name)) {
+            final requestForSymbol = request[prop.name];
             // MediaMessage special case
-            if (request[prop.name] is MediaMessage ||
-                request[prop.name] is List<MediaMessage>) {
+            if (requestForSymbol is MediaMessage ||
+                requestForSymbol is List<MediaMessage>) {
               // If in form, there is an (input[type="file"] multiple) and the user
               // put only one file. It's not an error and it should be accept.
               // Maybe it cans be optimized.
-              if (schema.type.instanceMembers[sym].returnType.reflectedType
-                  .toString() ==
-                  'List<MediaMessage>' &&
-                  request[prop.name] is MediaMessage) {
-                schema.setField(sym, [request[prop.name]]);
-              } else if (request[prop.name] is List) {
-                schema.setField(sym, prop.fromRequest(request[prop.name]));
+              if (schema.type.instanceMembers[sym].returnType.reflectedType is List<MediaMessage> &&
+                  requestForSymbol is MediaMessage) {
+                schema.setField(sym, [requestForSymbol]);
+              } else if (requestForSymbol is List) {
+                schema.setField(sym, prop.fromRequest(requestForSymbol));
               } else {
-                schema.setField(sym, request[prop.name]);
+                schema.setField(sym, requestForSymbol);
               }
             } else {
-              schema.setField(sym, prop.fromRequest(request[prop.name]));
+              schema.setField(sym, prop.fromRequest(requestForSymbol));
             }
           } else if (prop.hasDefault) {
             schema.setField(sym, prop.fromRequest(prop.defaultValue));

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -990,8 +990,6 @@ class ApiParser {
     var schema = parseSchema(schemaTypeMirror, isRequest);
     ClassMirror schemaProperty = reflectType(SchemaProperty, [schemaTypeMirror.reflectedType]);
     return schemaProperty.newInstance(const Symbol(''), [propertyName, metadata.description, metadata.required, schema]).reflectee;
-    //return new SchemaProperty(
-    //    propertyName, metadata.description, metadata.required, schema);
   }
 
   /// Return the type arguments for the given class [T], which is or is a
@@ -1024,12 +1022,9 @@ class ApiParser {
     var listItemsProperty = parseProperty(
         listTypeArguments[0], propertyName, new ApiProperty(), isRequest);
 
-    ClassMirror listItemsPropertyMirror = reflect(listItemsProperty).type;
     // Pull the Dart type of the listItemsProperty and add it to the ListProperty's type parameters, then instantiate a new instance.
     ClassMirror listProperty = reflectType(ListProperty, [listTypeArguments.map<Type>((TypeMirror tm) => tm.reflectedType).first]);
     return listProperty.newInstance(const Symbol(''), [propertyName, metadata.description, metadata.required, listItemsProperty]).reflectee;
-    //return new ListProperty(propertyName, metadata.description,
-    //    metadata.required, listItemsProperty);
   }
 
   MapProperty parseMapProperty(String propertyName, ApiProperty metadata,

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -987,8 +987,10 @@ class ApiParser {
     var propertyTypeName = MirrorSystem.getName(schemaTypeMirror.simpleName);
     _checkValidFields(propertyName, propertyTypeName, metadata, []);
     var schema = parseSchema(schemaTypeMirror, isRequest);
-    return new SchemaProperty(
-        propertyName, metadata.description, metadata.required, schema);
+    ClassMirror schemaProperty = reflectType(SchemaProperty, [schemaTypeMirror.reflectedType]);
+    return schemaProperty.newInstance(const Symbol(''), [propertyName, metadata.description, metadata.required, schema]).reflectee;
+    //return new SchemaProperty(
+    //    propertyName, metadata.description, metadata.required, schema);
   }
 
   /// Return the type arguments for the given class [T], which is or is a

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -224,11 +224,11 @@ class ApiParser {
 
     // Parse name.
     var name = metadata.name;
-
     if (name == null || name.isEmpty) {
       // Default method name is method name in camel case.
       name = methodName;
     }
+
     // Method discovery document id.
     var discoveryId = _contextId;
 
@@ -633,6 +633,7 @@ class ApiParser {
         return existingSchemaConfig;
       }
     }
+
     ClassMirror namedMapSchema = reflectType(NamedMapSchema, [schemaClass.typeArguments[1].reflectedType]);
     var schemaConfig = namedMapSchema.newInstance(const Symbol(''), [name, schemaClass, isRequest]).reflectee;
     // We put in the schema before parsing properties to detect cycles.
@@ -1021,8 +1022,6 @@ class ApiParser {
     // TODO: Figure out what to do about metadata for the items property.
     var listItemsProperty = parseProperty(
         listTypeArguments[0], propertyName, new ApiProperty(), isRequest);
-
-    // Pull the Dart type of the listItemsProperty and add it to the ListProperty's type parameters, then instantiate a new instance.
     ClassMirror listProperty = reflectType(ListProperty, [listTypeArguments.map<Type>((TypeMirror tm) => tm.reflectedType).first]);
     return listProperty.newInstance(const Symbol(''), [propertyName, metadata.description, metadata.required, listItemsProperty]).reflectee;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: rpc
-version: 0.6.0
+version: 0.6.1
 author: Dart Team <misc@dartlang.org>
 description: Library for exposing Dart server-side APIs.
 homepage: https://github.com/dart-lang/rpc


### PR DESCRIPTION
Fixes #133.

@supermuka

I believe this should be a complete set of changes for the rpc package to support strong-mode mirrors (dart-lang/sdk#35611).  It passes all tests on Dart 2.0.0, Dart 2.1.0, and bleeding edge (with strong-mode mirrors) and seems to work just fine with dart-services.