### PR TITLE
Fixes Dart 2.5.0 Utf8Decoder break

### DIFF
--- a/lib/src/config/method.dart
+++ b/lib/src/config/method.dart
@@ -301,8 +301,8 @@ class ApiConfigMethod {
       // it to the list of position parameters.
       final schema = _requestSchema.fromRequest(decodedRequest);
       positionalParams.add(schema);
-    } catch (error) {
-      rpcLogger.warning('Failed to decode request body: $error');
+    } catch (error, st) {
+      rpcLogger.warning('Failed to decode request body: $error ($st)');
       if (error is FormatException) {
         if (error.message == 'Unexpected end of input') {
           // The method expects a body and none was passed.

--- a/lib/src/config/method.dart
+++ b/lib/src/config/method.dart
@@ -301,8 +301,8 @@ class ApiConfigMethod {
       // it to the list of position parameters.
       final schema = _requestSchema.fromRequest(decodedRequest);
       positionalParams.add(schema);
-    } catch (error, st) {
-      rpcLogger.warning('Failed to decode request body: $error ($st)');
+    } catch (error) {
+      rpcLogger.warning('Failed to decode request body: $error');
       if (error is FormatException) {
         if (error.message == 'Unexpected end of input') {
           // The method expects a body and none was passed.

--- a/lib/src/http_body_parser.dart
+++ b/lib/src/http_body_parser.dart
@@ -37,8 +37,7 @@ Future<PostData> _asText(ParsedHttpApiRequest request) {
   final String charset = request.contentType.charset;
   final Encoding encoding =
       charset != null ? Encoding.getByName(charset) : utf8;
-  return request.body
-      .transform(encoding.decoder)
+  return encoding.decoder.bind(request.body)
       .fold(new StringBuffer(), _fillStringBuffer)
       .then((StringBuffer buffer) => new PostData('text', buffer.toString()));
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: rpc
-version: 0.6.1
+version: 0.6.1+1
 author: Dart Team <misc@dartlang.org>
 description: Library for exposing Dart server-side APIs.
 homepage: https://github.com/dart-lang/rpc

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: rpc
-version: 0.6.1+1
+version: 0.6.2
 author: Dart Team <misc@dartlang.org>
 description: Library for exposing Dart server-side APIs.
 homepage: https://github.com/dart-lang/rpc

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: rpc
-version: 0.6.2
+version: 0.6.1+1
 author: Dart Team <misc@dartlang.org>
 description: Library for exposing Dart server-side APIs.
 homepage: https://github.com/dart-lang/rpc


### PR DESCRIPTION
Applies the fix for the Uint8List-related breaking change described here:

https://github.com/dart-lang/sdk/blob/master/CHANGELOG.md#core-libraries-1

This is necessary to get https://github.com/dart-lang/dart-services working with Dart 2.5.0. 